### PR TITLE
Feature/semester db migration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Run All Tests (Lint, Jest, Cypress)",
       "type": "shell",
-      "command": "yarn lint && yarn test && yarn cypress:run",
+      "command": "npm run lint && npm run test && npm run cypress",
       "group": {
         "kind": "test",
         "isDefault": true
@@ -18,7 +18,7 @@
     {
       "label": "Run Lint",
       "type": "shell",
-      "command": "yarn lint",
+      "command": "npm run lint",
       "group": "test",
       "presentation": {
         "reveal": "always",
@@ -29,7 +29,7 @@
     {
       "label": "Run Jest Tests",
       "type": "shell",
-      "command": "yarn test",
+      "command": "npm run test",
       "group": "test",
       "presentation": {
         "reveal": "always",
@@ -40,7 +40,7 @@
     {
       "label": "Run Cypress Tests (E2E)",
       "type": "shell",
-      "command": "yarn cypress:run",
+      "command": "npm run cypress",
       "group": "test",
       "presentation": {
         "reveal": "always",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,6 @@
 2. Use `npm` as the package manager.
 3. Create or update the Jest unit test to have good coverage and to pass for the modified code.
 4. If you're updating code in non-minor ways, also run the Cypress e2e test suite via `npm run cypress` and `npm run build`. It takes a few minutes so do it sparingly.
-5. For Cypress e2e tests or other HTTP based testing, try to use my already running dev server on <http://localhost:5173> for testing, but start your own if that isn't running or use `npm run cypress:run` which starts the server, runs the tests, and then stops the server. But if it fails because the Firestore Emulator isn't running (the Cypress tests check for that early on), ask the user to start the emulator and seed the database as instructed in [README.md](README.md).
+5. For Cypress e2e tests or other HTTP based testing, try to use my already running dev server on <http://localhost:5173> for testing, but start your own if that isn't running. But if it fails because the Firestore Emulator isn't running (the Cypress tests check for that early on), ask the user to start the emulator and seed the database as instructed in [README.md](README.md).
 6. We use Prettier for code formatting, which you can run via `npm run format`.
 7. Before you say you're done, run `npm run lint && npm run test` to unit test the entire project via Jest, and ensure the lint run is clean. If your changes are very minor, such as Jest test-only or CSS-only changes, you may skip running the Cypress tests.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Open [http://localhost:5173](http://localhost:5173) with your browser to see the
 
 To transition the gbSTEM system to a new semester, configuration and course catalog updates must be applied.
 
-For detailed, step-by-step instructions on how to transition the collections, copy the updated course catalog configurations, and deploy the required Firebase extensions, please refer to the **[Adding a New Semester section in the Admin Repository's README.md](https://github.com/gbstem/admin/blob/main/README.md#adding-a-new-semester)**.
+For detailed, step-by-step instructions on updating the semester suffix and copying the updated course catalog configurations, please refer to the **[Adding a New Semester section in the Admin Repository's README.md](https://github.com/gbstem/admin/blob/main/README.md#adding-a-new-semester)**.
 
 ## Updating Dependencies
 

--- a/__tests__/collections.test.ts
+++ b/__tests__/collections.test.ts
@@ -8,7 +8,7 @@ import {
   maxChildrenPerAccount,
   registrationsCollection,
   semesterCollectionPath,
-  semesterDatesDocument,
+  semesterDates,
   studentFeedbackCollection,
   substituteRequestsCollection,
   withSemester,
@@ -45,9 +45,50 @@ describe('collections.ts', () => {
   })
 
   it('leaves non-semesterized collections and constants unchanged', () => {
-    expect(semesterDatesDocument).toBe(currentSemester.toLowerCase())
     expect(substituteRequestsCollection).toBe('subRequests')
     expect(maxChildrenPerAccount).toBe(5)
+  })
+
+  // semesterDates.json is hand-edited each semester rollover (copied from the admin repo's
+  // copy - no more Firestore document, see admin/README.md's "Adding a New Semester"), so
+  // it's worth validating its shape here rather than only discovering a typo/wrong-year/
+  // out-of-sync-with-admin mistake at runtime.
+  describe('semesterDates', () => {
+    const expectedYear = currentSemester.match(/\d\d$/)?.[0] as string
+
+    it('has exactly the expected fields', () => {
+      expect(Object.keys(semesterDates).sort()).toEqual(
+        [
+          'classesEnd',
+          'classesStart',
+          'instructorOrientation',
+          'newInstructorAppsDue',
+          'newInstructorAppsOpen',
+          'parentOrientation',
+          'registrationsDue',
+          'registrationsOpen',
+          'returningInstructorAppsDue',
+          'returningInstructorAppsOpen',
+          'studentOrientation',
+        ].sort(),
+      )
+    })
+
+    // Object.entries() on a plain (non-index-signature) object type falls back to a
+    // less-precise overload that types values as `unknown` - cast once here rather than at
+    // every destructured usage below.
+    const semesterDateEntries = Object.entries(semesterDates) as Array<
+      [string, string]
+    >
+
+    it.each(semesterDateEntries)(
+      '%s is a valid MM/DD/YY date whose year matches currentSemester',
+      (_field, value) => {
+        expect(value).toMatch(/^\d{2}\/\d{2}\/\d{2}$/)
+        expect(new Date(value).toString()).not.toBe('Invalid Date')
+        expect(value.slice(-2)).toBe(expectedYear)
+      },
+    )
   })
 
   describe('semesterCollectionPath', () => {

--- a/__tests__/collections.test.ts
+++ b/__tests__/collections.test.ts
@@ -1,0 +1,75 @@
+import {
+  applicationsCollection,
+  classesCollection,
+  currentSemester,
+  decisionsCollection,
+  instructorFeedbackCollection,
+  interviewCollection,
+  maxChildrenPerAccount,
+  registrationsCollection,
+  semesterCollectionPath,
+  semesterDatesDocument,
+  studentFeedbackCollection,
+  substituteRequestsCollection,
+  withSemester,
+} from '../src/lib/data/collections'
+
+describe('collections.ts', () => {
+  // Guards the assumption the rest of this file's assertions are built on: that
+  // currentSemester is a `{Spring,Fall}{2-digit year}` id (e.g. "Spring26"), not some other
+  // format. Assertions below are parameterized off currentSemester (rather than hardcoding
+  // e.g. "Spring26") so they don't need editing every time a new semester rolls in — this
+  // check is what keeps that parameterization honest instead of silently matching anything.
+  it('currentSemester matches the expected (Spring|Fall)\\d\\d format', () => {
+    expect(currentSemester).toMatch(/^(Spring|Fall)\d\d$/)
+  })
+
+  it('exports semester-scoped subcollection paths for the current semester', () => {
+    expect(applicationsCollection).toBe(
+      `semesters/${currentSemester}/applications`,
+    )
+    expect(classesCollection).toBe(`semesters/${currentSemester}/classes`)
+    expect(decisionsCollection).toBe(`semesters/${currentSemester}/decisions`)
+    expect(instructorFeedbackCollection).toBe(
+      `semesters/${currentSemester}/instructorFeedback`,
+    )
+    expect(interviewCollection).toBe(
+      `semesters/${currentSemester}/instructorInterviewTimes`,
+    )
+    expect(registrationsCollection).toBe(
+      `semesters/${currentSemester}/registrations`,
+    )
+    expect(studentFeedbackCollection).toBe(
+      `semesters/${currentSemester}/classFeedback`,
+    )
+  })
+
+  it('leaves non-semesterized collections and constants unchanged', () => {
+    expect(semesterDatesDocument).toBe(currentSemester.toLowerCase())
+    expect(substituteRequestsCollection).toBe('subRequests')
+    expect(maxChildrenPerAccount).toBe(5)
+  })
+
+  describe('semesterCollectionPath', () => {
+    it('builds a semesters/{semesterId}/{name} path', () => {
+      expect(semesterCollectionPath('Fall25', 'registrations')).toBe(
+        'semesters/Fall25/registrations',
+      )
+    })
+  })
+
+  describe('withSemester', () => {
+    it('stamps the current semester', () => {
+      expect(withSemester({ foo: 'bar' })).toEqual({
+        foo: 'bar',
+        semester: currentSemester,
+      })
+    })
+
+    it('does not mutate the original object', () => {
+      const original = { foo: 'bar' }
+      withSemester(original)
+      expect(original).toEqual({ foo: 'bar' })
+    })
+  })
+})

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { initializeApp, getApps } from 'firebase-admin/app'
 import { getAuth } from 'firebase-admin/auth'
+import { getFirestore } from 'firebase-admin/firestore'
 import { fileURLToPath } from 'url'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -90,6 +91,19 @@ export default defineConfig({
             console.error('Error in getFirestoreUserId task:', error)
             return null
           }
+        },
+        // Admin SDK access bypasses firestore.rules (unlike a plain cy.request() against the
+        // Firestore REST API, which enforces them and 403s for an unauthenticated caller) -
+        // needed for tests asserting server-side document state directly, such as confirming a
+        // doc was actually deleted rather than just reflected in optimistic UI state.
+        async checkFirestoreDocExists(docPath: string) {
+          if (getApps().length === 0) {
+            initializeApp({
+              projectId: process.env.FIREBASE_PROJECT_ID || 'demo-gbstem',
+            })
+          }
+          const doc = await getFirestore().doc(docPath).get()
+          return doc.exists
         },
       })
       return config

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -107,4 +107,74 @@ describe('Section F: Profile Customization & Account Management', () => {
       })
     cy.url().should('include', '/signin', { timeout: 10000 })
   })
+
+  // TODO(dmeyer246) Ensure this gets enabled, run, and succeeds. Then remove the overly verbose
+  // test case comment below.
+  //
+  // Regression test for SEMESTER_MIGRATION_PLAN.md § 10.2: DeleteAccountForm.svelte deleted
+  // the application doc via a hardcoded `doc(db, 'applications', uid)` instead of the imported
+  // `applicationsCollection` constant, which has no matching security rule under either the old
+  // or new schema and fails with permission-denied — silently, because the surrounding
+  // `.map((p) => p.catch((e) => e))` swallows the error. Test Case 12 above already exercises
+  // the delete-account UI flow end-to-end, but its test user signs up with the "Parent
+  // registering my child for classes" role, which never has an application doc in the first
+  // place (only the "instructor" role does, via ApplyForm), so it would not have caught this
+  // bug even with a Firestore assertion added to it.
+  //
+  // SKIPPED: needs an instructor-role signup, a visit to /apply (ApplyForm auto-creates a draft
+  // application doc on mount — see ApplyForm.svelte's onMount/handleSave), then a direct
+  // Firestore emulator REST check (following the same `cy.request` pattern getLatestOobLink uses
+  // against the Auth emulator, at `127.0.0.1:8080/v1/projects/demo-gbstem/databases/(default)/
+  // documents/semesters/{currentSemester}/applications/{uid}`, expecting 404) after deletion —
+  // none of which has been runtime-verified yet. Un-skip once verified during the Phase 4
+  // emulator rehearsal.
+  it.skip('Test Case 13: Deleting An Instructor Account Removes Their Application (TODO: verify Firestore REST assertion works)', () => {
+    const emailPrefix = generateDateHash('delete-instructor')
+    const email = `${emailPrefix}@gbstem.org`
+    const password = 'password123'
+
+    cy.loadSignupPage()
+    cy.selectOption(
+      'input[name="role"]',
+      'High school/college student applying to be an instructor',
+    )
+    cy.fillInput('input[name="firstName"]', 'DeleteMe')
+    cy.fillInput('input[name="lastName"]', 'Instructor')
+    cy.fillInput('input[name="email"]', email)
+    cy.fillInput('input[name="password"]', password)
+    cy.fillInput('input[name="confirmPassword"]', password)
+    cy.contains('button', 'Sign up').click()
+    cy.get('[role="dialog"]').contains('button', 'Go to dashboard').click()
+    cy.getLatestOobLink(email, 'VERIFY_EMAIL').then((link) => {
+      cy.request(link)
+    })
+
+    // TODO: capture the signed-up user's uid (e.g. via a custom command reading it off the
+    // Auth emulator, mirroring getLatestOobLink's REST call) so it can be used below.
+    const uid = 'TODO_CAPTURE_UID'
+
+    // Visiting /apply as an instructor auto-creates a draft application doc.
+    cy.visit('/apply')
+    cy.wait(2000)
+
+    cy.visit('/profile')
+    cy.wait(1000)
+    cy.contains('button', 'Delete account').click()
+    cy.get('[role="dialog"]')
+      .last()
+      .within(() => {
+        cy.get('input[name="password"]').clear().type(password)
+        cy.contains('button', 'Delete').click()
+      })
+    cy.url().should('include', '/signin', { timeout: 10000 })
+
+    // TODO: replace 'Spring26' with the live currentSemester export once this test is wired up.
+    cy.request({
+      method: 'GET',
+      url: `http://127.0.0.1:8080/v1/projects/demo-gbstem/databases/(default)/documents/semesters/Spring26/applications/${uid}`,
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(404)
+    })
+  })
 })

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -1,3 +1,4 @@
+import { currentSemester } from '../../src/lib/data/collections'
 import { generateDateHash } from '../support/utils'
 
 describe('Section F: Profile Customization & Account Management', () => {
@@ -108,9 +109,6 @@ describe('Section F: Profile Customization & Account Management', () => {
     cy.url().should('include', '/signin', { timeout: 10000 })
   })
 
-  // Note: 'Spring26' below is the current semester (collections.ts's `currentSemester`),
-  // hardcoded rather than imported since Cypress specs in this repo don't import app source -
-  // update it alongside the `suffix` constant when the semester rolls over.
   it('Test Case 13: Deleting An Instructor Account Removes Their Application', () => {
     const emailPrefix = generateDateHash('delete-instructor')
     const email = `${emailPrefix}@gbstem.org`
@@ -143,7 +141,7 @@ describe('Section F: Profile Customization & Account Management', () => {
       expect(uid).to.be.a('string')
       expect((uid as string).length).to.be.greaterThan(0)
 
-      const applicationDocPath = `semesters/Spring26/applications/${uid}`
+      const applicationDocPath = `semesters/${currentSemester}/applications/${uid}`
 
       // Confirm the application doc actually exists before deletion, so the "gone after
       // deletion" check below can't be a false pass from it never having been created.

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -108,27 +108,10 @@ describe('Section F: Profile Customization & Account Management', () => {
     cy.url().should('include', '/signin', { timeout: 10000 })
   })
 
-  // TODO(dmeyer246) Ensure this gets enabled, run, and succeeds. Then remove the overly verbose
-  // test case comment below.
-  //
-  // Regression test for SEMESTER_MIGRATION_PLAN.md § 10.2: DeleteAccountForm.svelte deleted
-  // the application doc via a hardcoded `doc(db, 'applications', uid)` instead of the imported
-  // `applicationsCollection` constant, which has no matching security rule under either the old
-  // or new schema and fails with permission-denied — silently, because the surrounding
-  // `.map((p) => p.catch((e) => e))` swallows the error. Test Case 12 above already exercises
-  // the delete-account UI flow end-to-end, but its test user signs up with the "Parent
-  // registering my child for classes" role, which never has an application doc in the first
-  // place (only the "instructor" role does, via ApplyForm), so it would not have caught this
-  // bug even with a Firestore assertion added to it.
-  //
-  // SKIPPED: needs an instructor-role signup, a visit to /apply (ApplyForm auto-creates a draft
-  // application doc on mount — see ApplyForm.svelte's onMount/handleSave), then a direct
-  // Firestore emulator REST check (following the same `cy.request` pattern getLatestOobLink uses
-  // against the Auth emulator, at `127.0.0.1:8080/v1/projects/demo-gbstem/databases/(default)/
-  // documents/semesters/{currentSemester}/applications/{uid}`, expecting 404) after deletion —
-  // none of which has been runtime-verified yet. Un-skip once verified during the Phase 4
-  // emulator rehearsal.
-  it.skip('Test Case 13: Deleting An Instructor Account Removes Their Application (TODO: verify Firestore REST assertion works)', () => {
+  // Note: 'Spring26' below is the current semester (collections.ts's `currentSemester`),
+  // hardcoded rather than imported since Cypress specs in this repo don't import app source -
+  // update it alongside the `suffix` constant when the semester rolls over.
+  it('Test Case 13: Deleting An Instructor Account Removes Their Application', () => {
     const emailPrefix = generateDateHash('delete-instructor')
     const email = `${emailPrefix}@gbstem.org`
     const password = 'password123'
@@ -149,32 +132,38 @@ describe('Section F: Profile Customization & Account Management', () => {
       cy.request(link)
     })
 
-    // TODO: capture the signed-up user's uid (e.g. via a custom command reading it off the
-    // Auth emulator, mirroring getLatestOobLink's REST call) so it can be used below.
-    const uid = 'TODO_CAPTURE_UID'
-
     // Visiting /apply as an instructor auto-creates a draft application doc.
     cy.visit('/apply')
     cy.wait(2000)
 
-    cy.visit('/profile')
-    cy.wait(1000)
-    cy.contains('button', 'Delete account').click()
-    cy.get('[role="dialog"]')
-      .last()
-      .within(() => {
-        cy.get('input[name="password"]').clear().type(password)
-        cy.contains('button', 'Delete').click()
-      })
-    cy.url().should('include', '/signin', { timeout: 10000 })
+    // getFirestoreUserId/checkFirestoreDocExists use the Admin SDK (cypress.config.ts task),
+    // which bypasses firestore.rules - unlike a plain cy.request() against the Firestore REST
+    // API, which enforces them and would 403 for this unauthenticated check.
+    cy.task('getFirestoreUserId', email).then((uid) => {
+      expect(uid).to.be.a('string')
+      expect((uid as string).length).to.be.greaterThan(0)
 
-    // TODO: replace 'Spring26' with the live currentSemester export once this test is wired up.
-    cy.request({
-      method: 'GET',
-      url: `http://127.0.0.1:8080/v1/projects/demo-gbstem/databases/(default)/documents/semesters/Spring26/applications/${uid}`,
-      failOnStatusCode: false,
-    }).then((res) => {
-      expect(res.status).to.eq(404)
+      const applicationDocPath = `semesters/Spring26/applications/${uid}`
+
+      // Confirm the application doc actually exists before deletion, so the "gone after
+      // deletion" check below can't be a false pass from it never having been created.
+      cy.task('checkFirestoreDocExists', applicationDocPath).should('eq', true)
+
+      cy.visit('/profile')
+      cy.wait(1000)
+      cy.contains('button', 'Delete account').click()
+      cy.get('[role="dialog"]')
+        .last()
+        .within(() => {
+          cy.get('input[name="password"]').clear().type(password)
+          cy.contains('button', 'Delete').click()
+        })
+      cy.url().should('include', '/signin', { timeout: 10000 })
+
+      cy.task('checkFirestoreDocExists', applicationDocPath).should(
+        'eq',
+        false,
+      )
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "format:check": "prettier . --check .",
     "format": "prettier --write --plugin prettier-plugin-svelte --plugin prettier-plugin-tailwindcss .",
     "test": "jest",
-    "cypress:run": "start-server-and-test start http://localhost:3000 cypress",
     "cypress": "cypress run",
     "deploy": "npm run build && firebase deploy",
     "emulators": "firebase emulators:start --log-verbosity=quiet",

--- a/src/data.d.ts
+++ b/src/data.d.ts
@@ -54,10 +54,11 @@ declare global {
       html: string
     }
 
+    // MM/DD/YY strings; see src/lib/data/semesterDates.json and
+    // collections.ts's `semesterDates` export.
     type SemesterDates = {
       classesEnd: string
       classesStart: string
-      leadershipAppsDue: string
       newInstructorAppsDue: string
       returningInstructorAppsDue: string
       instructorOrientation: string

--- a/src/lib/components/ClassSchedule.svelte
+++ b/src/lib/components/ClassSchedule.svelte
@@ -727,7 +727,7 @@
       <li
         class="relative flex flex-wrap items-center justify-between gap-4 rounded-xl border bg-white p-4 shadow-sm transition hover:shadow-lg"
       >
-        <div class="flex min-w-[200px] flex-1 items-center gap-4">
+        <div class="flex min-w-50 flex-1 items-center gap-4">
           <!-- Status badge -->
           {#if values.classStatuses[classNumber] === ClassStatus.ClassNotHeld}
             <span

--- a/src/lib/components/FormTextarea.svelte
+++ b/src/lib/components/FormTextarea.svelte
@@ -56,7 +56,7 @@
           maxlength={$$restProps.maxlength ?? fieldConstraints?.maxlength}
           bind:value
           class={cn(
-            'mt-1 block min-h-[120px] w-full appearance-none rounded-md border border-gray-400 p-3 transition-colors placeholder:text-gray-500 focus:border-gray-600 focus:outline-hidden disabled:bg-white disabled:text-gray-400',
+            'mt-1 block min-h-30 w-full appearance-none rounded-md border border-gray-400 p-3 transition-colors placeholder:text-gray-500 focus:border-gray-600 focus:outline-hidden disabled:bg-white disabled:text-gray-400',
             className,
           )}
           {...$$restProps}

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -79,7 +79,7 @@
         {#each pages as page}
           <a
             class={cn(
-              'relative rounded-full px-1.5 py-1 text-[11px] md:px-2 md:py-1.5 md:text-xs lg:px-2.5 lg:py-2 lg:text-sm xl:px-4 xl:text-base font-medium transition-colors duration-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 text-center leading-tight flex items-center justify-center min-h-10 max-w-[120px] shrink-0',
+              'relative rounded-full px-1.5 py-1 text-[11px] md:px-2 md:py-1.5 md:text-xs lg:px-2.5 lg:py-2 lg:text-sm xl:px-4 xl:text-base font-medium transition-colors duration-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 text-center leading-tight flex items-center justify-center min-h-10 max-w-30 shrink-0',
               pathname === page.href
                 ? 'bg-blue-100 text-blue-700 shadow-xs'
                 : 'hover:bg-gray-100 hover:text-blue-600',

--- a/src/lib/components/forms/ApplyForm.svelte
+++ b/src/lib/components/forms/ApplyForm.svelte
@@ -11,7 +11,7 @@
   import type { FirebaseError } from 'firebase/app'
   import Card from '$lib/components/Card.svelte'
   import { coursesJson, gendersJson, raceJson, reasonsJson } from '$lib/data'
-  import { applicationsCollection } from '$lib/data/collections'
+  import { applicationsCollection, withSemester } from '$lib/data/collections'
   import { superForm, defaults } from 'sveltekit-superforms'
   import { zod } from 'sveltekit-superforms/adapters'
   import { applicationSchema } from './schemas'
@@ -178,7 +178,7 @@
           }
           setDoc(
             doc(db, applicationsCollection, frozenUser.object.uid),
-            updatedValues,
+            withSemester(updatedValues),
           )
             .then(() => {
               getDoc(
@@ -316,7 +316,7 @@
         }
         setDoc(
           doc(db, applicationsCollection, frozenUser.object.uid),
-          updatedValues,
+          withSemester(updatedValues),
         )
           .then(() => {
             getDoc(doc(db, applicationsCollection, frozenUser.object.uid)).then(

--- a/src/lib/components/forms/ApplyForm.svelte
+++ b/src/lib/components/forms/ApplyForm.svelte
@@ -26,7 +26,6 @@
   export let semesterDates: Data.SemesterDates = {
     classesEnd: '',
     classesStart: '',
-    leadershipAppsDue: '',
     newInstructorAppsDue: '',
     returningInstructorAppsDue: '',
     instructorOrientation: '',

--- a/src/lib/components/forms/ClassDetailsForm.svelte
+++ b/src/lib/components/forms/ClassDetailsForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { db, user } from '$lib/client/firebase'
   import { coursesJson, daysOfWeekJson } from '$lib/data'
-  import { classesCollection } from '$lib/data/collections'
+  import { classesCollection, withSemester } from '$lib/data/collections'
   import { alert } from '$lib/stores'
   import {
     cn,
@@ -178,7 +178,10 @@
               classId = `${frozenUser.object.uid}-${classNumber}`
             }
 
-            await setDoc(doc(db, classesCollection, classId), newValues)
+            await setDoc(
+              doc(db, classesCollection, classId),
+              withSemester(newValues),
+            )
 
             await updateInstructorClassMappings(
               classId,

--- a/src/lib/components/forms/DeleteAccountForm.svelte
+++ b/src/lib/components/forms/DeleteAccountForm.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { db, storage, user } from '$lib/client/firebase'
   import Dialog from '$lib/components/Dialog.svelte'
-  import { decisionsCollection } from '$lib/data/collections'
+  import {
+    applicationsCollection,
+    decisionsCollection,
+  } from '$lib/data/collections'
   import { alert } from '$lib/stores'
   import {
     EmailAuthProvider,
@@ -48,7 +51,9 @@
             await Promise.all(
               [
                 deleteObject(resumeRef),
-                deleteDoc(doc(db, 'applications', frozenUser.object.uid)),
+                deleteDoc(
+                  doc(db, applicationsCollection, frozenUser.object.uid),
+                ),
                 deleteDoc(doc(db, decisionsCollection, frozenUser.object.uid)),
               ].map((p) => p.catch((e) => e)),
             )

--- a/src/lib/components/forms/InstructorFeedbackForm.svelte
+++ b/src/lib/components/forms/InstructorFeedbackForm.svelte
@@ -5,6 +5,7 @@
     instructorFeedbackCollection,
     registrationsCollection,
     substituteRequestsCollection,
+    withSemester,
   } from '$lib/data/collections'
   import { alert } from '$lib/stores'
   import { cn } from '$lib/utils'
@@ -99,7 +100,7 @@
           try {
             await setDoc(
               doc(db, instructorFeedbackCollection, `${id}-${Date.now()}`),
-              submissionValues,
+              withSemester(submissionValues),
             )
             await updateDoc(doc(db, classesCollection, id), {
               feedbackCompleted: feedbackCompletedArray,

--- a/src/lib/components/forms/RegistrationForm.svelte
+++ b/src/lib/components/forms/RegistrationForm.svelte
@@ -20,7 +20,7 @@
   import Card from '$lib/components/Card.svelte'
   import { db, user } from '$lib/client/firebase'
   import { cloneDeep, isEqual } from 'lodash-es'
-  import { registrationsCollection } from '$lib/data/collections'
+  import { registrationsCollection, withSemester } from '$lib/data/collections'
   import { superForm, defaults } from 'sveltekit-superforms'
   import { zod } from 'sveltekit-superforms/adapters'
   import { registrationSchema } from './schemas'
@@ -146,7 +146,10 @@
               updated: serverTimestamp(),
             },
           }
-          setDoc(doc(db, registrationsCollection, childUid), updatedValues)
+          setDoc(
+            doc(db, registrationsCollection, childUid),
+            withSemester(updatedValues),
+          )
             .then(() => {
               getDoc(doc(db, registrationsCollection, childUid)).then(
                 (applicationDoc) => {
@@ -353,7 +356,10 @@
             updated: serverTimestamp(),
           },
         }
-        setDoc(doc(db, registrationsCollection, childUid), updatedValues)
+        setDoc(
+          doc(db, registrationsCollection, childUid),
+          withSemester(updatedValues),
+        )
           .then(() => {
             getDoc(doc(db, registrationsCollection, childUid)).then(
               (applicationDoc) => {

--- a/src/lib/components/forms/RegistrationForm.svelte
+++ b/src/lib/components/forms/RegistrationForm.svelte
@@ -34,7 +34,6 @@
   export let semesterDates: Data.SemesterDates = {
     classesEnd: '',
     classesStart: '',
-    leadershipAppsDue: '',
     newInstructorAppsDue: '',
     returningInstructorAppsDue: '',
     instructorOrientation: '',
@@ -497,7 +496,7 @@
     </div>
   </Card>
 {:else}
-  {#if new Date() >= new Date(semesterDates.registrationsDue + 604800000) && !values.meta.submitted}
+  {#if new Date().getTime() >= new Date(semesterDates.registrationsDue).getTime() + 604800000 && !values.meta.submitted}
     <Card class="mb-6 max-w-2xl border-red-200 bg-red-50">
       <div class="flex items-start gap-3">
         <svg

--- a/src/lib/components/forms/StudentFeedbackForm.svelte
+++ b/src/lib/components/forms/StudentFeedbackForm.svelte
@@ -4,6 +4,7 @@
     classesCollection,
     registrationsCollection,
     studentFeedbackCollection,
+    withSemester,
   } from '$lib/data/collections'
   import { alert, selectedStudentId } from '$lib/stores'
   import { cn } from '$lib/utils'
@@ -79,7 +80,7 @@
               studentFeedbackCollection,
               `${formVal.data.classId}-${Date.now()}`,
             ),
-            submissionValues,
+            withSemester(submissionValues),
           )
             .then(() => {
               alert.trigger('success', 'Class Feedback saved!')

--- a/src/lib/data/collections.ts
+++ b/src/lib/data/collections.ts
@@ -1,13 +1,41 @@
 const suffix = 'Spring26'
 
-export const applicationsCollection = 'applications' + suffix
-export const classesCollection = 'classes' + suffix
-export const decisionsCollection = 'decisions' + suffix
-export const instructorFeedbackCollection = 'instructorFeedback' + suffix
-export const interviewCollection = 'instructorInterviewTimes' + suffix
-export const registrationsCollection = 'registrations' + suffix
+export const currentSemester = suffix
+
+export const semesterCollectionPath = (semesterId: string, name: string) =>
+  `semesters/${semesterId}/${name}`
+
+export const applicationsCollection = semesterCollectionPath(
+  suffix,
+  'applications',
+)
+export const classesCollection = semesterCollectionPath(suffix, 'classes')
+export const decisionsCollection = semesterCollectionPath(suffix, 'decisions')
+export const instructorFeedbackCollection = semesterCollectionPath(
+  suffix,
+  'instructorFeedback',
+)
+export const interviewCollection = semesterCollectionPath(
+  suffix,
+  'instructorInterviewTimes',
+)
+export const registrationsCollection = semesterCollectionPath(
+  suffix,
+  'registrations',
+)
 export const semesterDatesDocument = suffix.toLowerCase()
-export const studentFeedbackCollection = 'classFeedback' + suffix
+export const studentFeedbackCollection = semesterCollectionPath(
+  suffix,
+  'classFeedback',
+)
 export const substituteRequestsCollection = 'subRequests'
 
 export const maxChildrenPerAccount = 5
+
+// Stamps a `semester` field onto a document being created/overwritten so it can be
+// filtered on in the shared (cross-semester) Algolia index the admin site searches
+// against. The portal only ever writes to the current semester (no past-semester
+// browsing here, unlike admin), so this always stamps currentSemester.
+export const withSemester = <T extends object>(
+  values: T,
+): T & { semester: string } => ({ ...values, semester: currentSemester })

--- a/src/lib/data/collections.ts
+++ b/src/lib/data/collections.ts
@@ -1,3 +1,5 @@
+import semesterDatesJson from './semesterDates.json'
+
 const suffix = 'Spring26'
 
 export const currentSemester = suffix
@@ -23,7 +25,10 @@ export const registrationsCollection = semesterCollectionPath(
   suffix,
   'registrations',
 )
-export const semesterDatesDocument = suffix.toLowerCase()
+// The current semester's key dates (MM/DD/YY strings), edited by hand alongside `suffix`
+// each semester rollover (copied from the admin repo's src/lib/data/semesterDates.json).
+// No longer a Firestore document - see __tests__/collections.test.ts's format/year validation.
+export const semesterDates: Data.SemesterDates = semesterDatesJson
 export const studentFeedbackCollection = semesterCollectionPath(
   suffix,
   'classFeedback',

--- a/src/lib/data/semesterDates.json
+++ b/src/lib/data/semesterDates.json
@@ -1,0 +1,13 @@
+{
+  "classesEnd": "06/13/26",
+  "classesStart": "03/15/26",
+  "instructorOrientation": "03/05/26",
+  "newInstructorAppsDue": "03/05/26",
+  "newInstructorAppsOpen": "02/01/26",
+  "parentOrientation": "03/08/26",
+  "registrationsDue": "03/08/26",
+  "registrationsOpen": "01/31/26",
+  "returningInstructorAppsDue": "02/14/26",
+  "returningInstructorAppsOpen": "01/31/26",
+  "studentOrientation": "03/08/26"
+}

--- a/src/routes/(signedIn)/(emailVerified)/apply/+page.svelte
+++ b/src/routes/(signedIn)/(emailVerified)/apply/+page.svelte
@@ -8,7 +8,7 @@
   import {
     maxChildrenPerAccount,
     registrationsCollection,
-    semesterDatesDocument,
+    semesterDates,
   } from '$lib/data/collections'
   import { alert } from '$lib/stores'
   import { doc, getDoc } from 'firebase/firestore'
@@ -23,31 +23,9 @@
   let value = ''
   let ready = false
   let uid = ''
-  let semesterDates: Data.SemesterDates = {
-    classesEnd: '',
-    classesStart: '',
-    leadershipAppsDue: '',
-    newInstructorAppsDue: '',
-    returningInstructorAppsDue: '',
-    instructorOrientation: '',
-    newInstructorAppsOpen: '',
-    returningInstructorAppsOpen: '',
-    studentOrientation: '',
-    registrationsDue: '',
-    parentOrientation: '',
-    registrationsOpen: '',
-  }
 
   const fetchData = async (user: Data.User.Store) => {
     uid = user.object.uid
-    await getDoc(doc(db, 'semesterDates', semesterDatesDocument)).then(
-      (datesDoc) => {
-        const datesDocExists = datesDoc.exists()
-        if (datesDocExists) {
-          semesterDates = datesDoc.data() as Data.SemesterDates
-        }
-      },
-    )
     for (let i = 1; i <= maxChildrenPerAccount; ++i) {
       const docRef = await getDoc(
         doc(db, registrationsCollection, `${uid}-${i}`),

--- a/src/routes/(signedIn)/(emailVerified)/classes/+page.svelte
+++ b/src/routes/(signedIn)/(emailVerified)/classes/+page.svelte
@@ -13,7 +13,7 @@
     classesCollection,
     maxChildrenPerAccount,
     registrationsCollection,
-    semesterDatesDocument,
+    semesterDates,
   } from '$lib/data/collections'
   import { alert } from '$lib/stores'
   import { formatClassTimes } from '$lib/utils'
@@ -55,21 +55,6 @@
 
   let classFilter = ''
   let onlyShowEnrolled = false
-
-  let semesterDates: Data.SemesterDates = {
-    classesEnd: '',
-    classesStart: '',
-    leadershipAppsDue: '',
-    newInstructorAppsDue: '',
-    returningInstructorAppsDue: '',
-    instructorOrientation: '',
-    newInstructorAppsOpen: '',
-    returningInstructorAppsOpen: '',
-    studentOrientation: '',
-    registrationsDue: '',
-    parentOrientation: '',
-    registrationsOpen: '',
-  }
 
   const studentUidToClassIds: {
     [studentUid: string]: string[]
@@ -180,12 +165,6 @@
   }
 
   onMount(() => {
-    getDoc(doc(db, 'semesterDates', semesterDatesDocument)).then((datesDoc) => {
-      const datesDocExists = datesDoc.exists()
-      if (datesDocExists) {
-        semesterDates = datesDoc.data() as Data.SemesterDates
-      }
-    })
     getData()
   })
 

--- a/src/routes/(signedIn)/(emailVerified)/dashboard/+page.svelte
+++ b/src/routes/(signedIn)/(emailVerified)/dashboard/+page.svelte
@@ -14,7 +14,7 @@
     decisionsCollection,
     maxChildrenPerAccount,
     registrationsCollection,
-    semesterDatesDocument,
+    semesterDates,
   } from '$lib/data/collections'
   import { doc, getDoc } from 'firebase/firestore'
 
@@ -42,21 +42,6 @@
     },
   }
 
-  let semesterDates: Data.SemesterDates = {
-    classesEnd: '',
-    classesStart: '',
-    leadershipAppsDue: '',
-    newInstructorAppsDue: '',
-    returningInstructorAppsDue: '',
-    instructorOrientation: '',
-    newInstructorAppsOpen: '',
-    returningInstructorAppsOpen: '',
-    studentOrientation: '',
-    registrationsDue: '',
-    parentOrientation: '',
-    registrationsOpen: '',
-  }
-
   let isStudent = false
 
   user.subscribe((userObj) => {
@@ -68,15 +53,10 @@
           if (userObj.profile.role === 'instructor') {
             data.application.status = null
 
-            const [datesDoc, applicationDoc, decisionDoc] = await Promise.all([
-              getDoc(doc(db, 'semesterDates', semesterDatesDocument)),
+            const [applicationDoc, decisionDoc] = await Promise.all([
               getDoc(doc(db, applicationsCollection, userObj.object.uid)),
               getDoc(doc(db, decisionsCollection, userObj.object.uid)),
             ])
-
-            if (datesDoc.exists()) {
-              semesterDates = datesDoc.data() as Data.SemesterDates
-            }
 
             if (applicationDoc.exists()) {
               const applicationData = applicationDoc.data() as Data.Application
@@ -90,9 +70,6 @@
             }
             data = data
           } else {
-            const datesPromise = getDoc(
-              doc(db, 'semesterDates', semesterDatesDocument),
-            )
             const registrationPromises = []
             for (let i = 1; i <= maxChildrenPerAccount; ++i) {
               registrationPromises.push(
@@ -105,14 +82,7 @@
                 ),
               )
             }
-            const [datesDoc, ...snapshots] = await Promise.all([
-              datesPromise,
-              ...registrationPromises,
-            ])
-
-            if (datesDoc.exists()) {
-              semesterDates = datesDoc.data() as Data.SemesterDates
-            }
+            const snapshots = await Promise.all(registrationPromises)
 
             numSubmitted = 0
             snapshots.forEach((snapshot) => {

--- a/src/routes/(signedIn)/(emailVerified)/dashboard/+page.svelte
+++ b/src/routes/(signedIn)/(emailVerified)/dashboard/+page.svelte
@@ -142,7 +142,7 @@
 
 <div class="mx-auto flex max-w-6xl flex-col items-center px-2 py-8 md:px-8">
   {#if loading}
-    <div class="w-full max-w-[620px] animate-pulse space-y-8">
+    <div class="w-full max-w-155 animate-pulse space-y-8">
       <!-- Card Skeleton 1 -->
       <div class="rounded-xl bg-white p-6 shadow-lg">
         <div class="mb-4 flex items-center">
@@ -174,7 +174,7 @@
     <div
       class="grid w-full gap-8 {hasRightColumn
         ? 'md:grid-cols-2'
-        : 'max-w-[620px] grid-cols-1'}"
+        : 'max-w-155 grid-cols-1'}"
     >
       <div class="flex flex-col gap-8">
         {#if $user?.profile?.role === 'instructor' && new Date() >= new Date(semesterDates.classesStart) && data.application.status === 'submitted'}

--- a/src/routes/(signedIn)/(emailVerified)/interview/+page.svelte
+++ b/src/routes/(signedIn)/(emailVerified)/interview/+page.svelte
@@ -1,39 +1,7 @@
 <script lang="ts">
-  import { db, user } from '$lib/client/firebase'
   import InterviewForm from '$lib/components/forms/InterviewForm.svelte'
   import PageLayout from '$lib/components/PageLayout.svelte'
-  import { semesterDatesDocument } from '$lib/data/collections'
-  import { getDoc, doc } from 'firebase/firestore'
-
-  let semesterDates: Data.SemesterDates = {
-    classesEnd: '',
-    classesStart: '',
-    leadershipAppsDue: '',
-    newInstructorAppsDue: '',
-    returningInstructorAppsDue: '',
-    instructorOrientation: '',
-    newInstructorAppsOpen: '',
-    returningInstructorAppsOpen: '',
-    studentOrientation: '',
-    registrationsDue: '',
-    registrationsOpen: '',
-    parentOrientation: '',
-  }
-
-  user.subscribe(async (u) => {
-    if (u) {
-      try {
-        const datesDoc = await getDoc(
-          doc(db, 'semesterDates', semesterDatesDocument),
-        )
-        if (datesDoc.exists()) {
-          semesterDates = datesDoc.data() as Data.SemesterDates
-        }
-      } catch (err) {
-        console.error('Failed to get semester dates:', err)
-      }
-    }
-  })
+  import { semesterDates } from '$lib/data/collections'
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This plan eliminates the per-semester Firestore setup ritual documented in [admin/README.md § Adding a New Semester](admin/README.md#adding-a-new-semester) by restructuring the database so that collections, indexes, security rules, and Algolia configuration are defined **once** and automatically cover every future semester. It spans both the **admin** and **portal** repositories, plus a one-time data migration that is fully rehearsable in the Firebase Emulator.