### PR TITLE
Fix stored HTML injection in transactional email templates

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -172,6 +172,16 @@ describe('utils', () => {
       const template = { data: { user: {} } }
       expect(addDataToHtmlTemplate(html, template)).toBe('Hello !')
     })
+
+    it('escapes HTML special characters to prevent injection', () => {
+      const html = 'Hello {{name}}!'
+      const template = {
+        data: { name: '<img src=x onerror=alert(1)>&"\'' },
+      }
+      expect(addDataToHtmlTemplate(html, template)).toBe(
+        'Hello &lt;img src=x onerror=alert(1)&gt;&amp;&quot;&#39;!',
+      )
+    })
   })
 
   describe('formatTime24to12', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,6 +56,15 @@ export function trapFocus(node: HTMLElement) {
   }
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 // replace html template with data
 export function addDataToHtmlTemplate(
   html: string,
@@ -71,7 +80,7 @@ export function addDataToHtmlTemplate(
         return ''
       }
     }
-    return String(value ?? '')
+    return escapeHtml(String(value ?? ''))
   })
   return htmlBody
 }


### PR DESCRIPTION
## Summary
- `addDataToHtmlTemplate()` (`src/lib/utils.ts`) substitutes `{{placeholder}}` values into HTML email bodies sent via SendGrid, but did so with **no escaping**.
- Several routes take these values directly from the request body of client-submitted forms and pass them straight through to the email — e.g. `api/application`, `api/registration`, `api/communityService`, `api/substitute`, `api/slotRequest`, `api/interview`, `api/enroll`, `api/action` — fields like `firstName`, `studentName`, `course`, `presidents`, `instructor`.
- An attacker could submit a payload like `<img src=x onerror=...>` as e.g. their first name and have it rendered unescaped into an HTML email (sent to themselves and, in several routes, CC'd to instructors/admins).
- Verified every `{{...}}` placeholder across all email templates sits only in plain-text nodes or double-quoted `href="..."` attributes, so HTML-entity escaping the substituted values is a complete, safe fix with no template changes required.
- Also audited for `{@html}` / `innerHTML`-style sinks in Svelte components — the only `{@html}` usage in this repo (`ClassSchedule.svelte`) renders a meeting-time-change email preview built entirely from formatted date strings (no free-text fields), so it's low risk and was left as is.
- Companion fix in `gbstem/admin` (same shared helper, same email routes pattern).

## Test plan
- [x] Added a regression test asserting `<script>`/`<img onerror>`-style payloads are HTML-escaped by `addDataToHtmlTemplate`
- [x] `yarn svelte-kit sync && yarn lint && yarn test` — clean, 362/362 tests pass