### PR TITLE
Require authentication on /api/token, remove wildcard CORS

### DIFF
--- a/__tests__/routes.test.ts
+++ b/__tests__/routes.test.ts
@@ -1,24 +1,3 @@
-// This jsdom test environment has no real `Response`/`fetch` globals, so
-// anything constructing a raw `new Response(...)` (rather than going
-// through the mocked @sveltejs/kit `json()` helper below) needs one. This
-// used to only stash `body`/`init` with no `.status`/`.headers`/`.json()`,
-// which is enough to satisfy `instanceof Response` but not enough to
-// actually assert on a route's response - tokenPOST/OPTIONS's tests need
-// the real thing.
-;(global as any).Response = class MockResponse {
-  body: any
-  status: number
-  headers: Map<string, string>
-  constructor(body: any, init: any = {}) {
-    this.body = body
-    this.status = init.status ?? 200
-    this.headers = new Map(Object.entries(init.headers ?? {}))
-  }
-  async json() {
-    return JSON.parse(this.body)
-  }
-}
-
 // Mock Svelte Store reset
 jest.mock(
   'svelte/store',
@@ -187,10 +166,7 @@ import { POST as registrationPOST } from '../src/routes/api/registration/+server
 import { POST as remindStudentsPOST } from '../src/routes/api/remindStudents/+server'
 import { POST as slotRequestPOST } from '../src/routes/api/slotRequest/+server'
 import { POST as substitutePOST } from '../src/routes/api/substitute/+server'
-import {
-  OPTIONS as tokenOPTIONS,
-  POST as tokenPOST,
-} from '../src/routes/api/token/+server'
+import { POST as tokenPOST } from '../src/routes/api/token/+server'
 import MailService from '@sendgrid/mail'
 
 // Shared helper for exercising the `catch (mailError)` branch that every
@@ -886,12 +862,7 @@ describe('API routes POST endpoints', () => {
     )
   })
 
-  // `fetch` isn't defined at all in this jsdom test environment, so without
-  // mocking it, POST always threw inside its own try block and this test
-  // was unknowingly exercising the *catch* branch under a "successfully"
-  // name - `toBeInstanceOf(Response)` passes either way since both branches
-  // return a Response. Mock fetch so success and failure are distinguishable.
-  describe('tokenPOST/OPTIONS', () => {
+  describe('tokenPOST', () => {
     const originalFetch = (global as any).fetch
 
     afterEach(() => {
@@ -903,32 +874,40 @@ describe('API routes POST endpoints', () => {
         json: jest.fn().mockResolvedValue({ access_token: 'abc123' }),
       })
 
-      const res = await tokenPOST({} as any)
+      const res = await tokenPOST({
+        locals: { user: { email: 'test@test.com' } },
+      } as any)
 
-      expect(res).toBeInstanceOf(Response)
-      expect(res.status).toBe(200)
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
-      await expect(res.json()).resolves.toEqual({ access_token: 'abc123' })
+      expect(res).toEqual(
+        expect.objectContaining({
+          body: { access_token: 'abc123' },
+          __isSvelteKitJson: true,
+        }),
+      )
     })
 
-    it('tokenPOST returns a 500 response when the token request fails', async () => {
+    it('tokenPOST returns a 500 json response when the token request fails', async () => {
       ;(global as any).fetch = jest
         .fn()
         .mockRejectedValue(new Error('network down'))
 
-      const res = await tokenPOST({} as any)
+      const res = await tokenPOST({
+        locals: { user: { email: 'test@test.com' } },
+      } as any)
 
-      expect(res).toBeInstanceOf(Response)
-      expect(res.status).toBe(500)
+      expect(res).toEqual(
+        expect.objectContaining({
+          body: {
+            error: 'Failed to fetch access token. Please try again later.',
+          },
+          init: { status: 500 },
+        }),
+      )
     })
 
-    it('tokenOPTIONS returns 200 with CORS headers', async () => {
-      const res = await tokenOPTIONS({} as any)
-
-      expect(res).toBeInstanceOf(Response)
-      expect(res.status).toBe(200)
-      expect(res.headers.get('Access-Control-Allow-Methods')).toBe(
-        'POST, GET, OPTIONS',
+    it('tokenPOST propagates the auth error when the user is not signed in', async () => {
+      await expect(tokenPOST({ locals: {} } as any)).rejects.toEqual(
+        expect.objectContaining({ status: 401, __isSvelteKitError: true }),
       )
     })
   })

--- a/src/routes/api/token/+server.ts
+++ b/src/routes/api/token/+server.ts
@@ -1,51 +1,37 @@
-import type { RequestHandler } from '@sveltejs/kit'
+import { handleApiError, verifyAuthenticated } from '$lib/server/apiHelpers'
 import { VITE_CLIENT_ID, VITE_CLIENT_SECRET } from '$env/static/private'
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
 
-export const POST: RequestHandler = async (): Promise<Response> => {
+export const POST: RequestHandler = async ({ locals }) => {
   try {
-    const response = await fetch(
-      'https://login.microsoftonline.com/c9f983d8-6c86-4534-8471-99c48eaab882/oauth2/v2.0/token',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
+    verifyAuthenticated(locals)
+
+    try {
+      const response = await fetch(
+        'https://login.microsoftonline.com/c9f983d8-6c86-4534-8471-99c48eaab882/oauth2/v2.0/token',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            client_id: VITE_CLIENT_ID,
+            scope: 'https://graph.microsoft.com/.default',
+            client_secret: VITE_CLIENT_SECRET,
+            grant_type: 'client_credentials',
+          }).toString(),
         },
-        body: new URLSearchParams({
-          client_id: VITE_CLIENT_ID,
-          scope: 'https://graph.microsoft.com/.default',
-          client_secret: VITE_CLIENT_SECRET,
-          grant_type: 'client_credentials',
-        }).toString(),
-      },
-    ).then((res) => res.json())
+      ).then((res) => res.json())
 
-    return new Response(JSON.stringify(response), {
-      status: 200,
-      headers: {
-        'Access-Control-Allow-Origin': '*', // Allow all origins
-        'Access-Control-Allow-Methods': 'POST, GET, OPTIONS', // Allow specific methods
-        'Access-Control-Allow-Headers': 'Content-Type', // Allow specific headers
-      },
-    })
+      return json(response)
+    } catch (tokenError) {
+      return json(
+        { error: 'Failed to fetch access token. Please try again later.' },
+        { status: 500 },
+      )
+    }
   } catch (err) {
-    return new Response(JSON.stringify(err), {
-      status: 500,
-      headers: {
-        'Access-Control-Allow-Origin': '*', // Allow all origins
-        'Access-Control-Allow-Methods': 'POST, GET, OPTIONS', // Allow specific methods
-        'Access-Control-Allow-Headers': 'Content-Type', // Allow specific headers
-      },
-    })
+    throw handleApiError('/api/token', err)
   }
-}
-
-export const OPTIONS: RequestHandler = async (): Promise<Response> => {
-  return new Response(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*', // Allow all origins
-      'Access-Control-Allow-Methods': 'POST, GET, OPTIONS', // Allow specific methods
-      'Access-Control-Allow-Headers': 'Content-Type', // Allow specific headers
-    },
-  })
 }


### PR DESCRIPTION
## Summary
Follow-up to a server-side auth/authz sweep: every sensitive route in this repo (and in `admin`) calls `verifyAuthenticated`/`verifyAdmin` first — except `/api/token`, which had no auth check at all.

- `/api/token` proxies a Microsoft Graph `client_credentials` token request using the app's own `VITE_CLIENT_ID`/`VITE_CLIENT_SECRET` server secrets, and returned the resulting bearer token verbatim.
- It also set `Access-Control-Allow-Origin: '*'`, so the response was readable cross-origin by any website's JS, not just same-origin `fetch` calls.
- Combined, this meant anyone on the internet — signed in or not — could obtain a live Graph API access token scoped to whatever the Azure AD app registration allows, with no session required.
- The only caller (`ClassDetailsForm.svelte`) runs from inside the signed-in `(emailVerified)` portal app and calls this same-origin, so the CORS headers served no purpose other than enabling the leak. Removed them, added `verifyAuthenticated(locals)` matching every other route, and routed errors through the shared `handleApiError` helper (also dropped the now-unused `OPTIONS` handler and the test-only `Response` polyfill it required).

## Test plan
- [x] Updated `tokenPOST` tests: success case, graceful 500 on a failed token fetch, and a new case asserting a 401 when `locals.user` is unset (matching the pattern used by every sibling route's auth test)
- [x] `yarn svelte-kit sync && yarn lint && yarn test` — clean, 362/362 tests pass
- [ ] Full Cypress e2e suite — not run locally (this box has an unrelated service already bound to port 8080, the Firestore emulator's port); relying on CI's `e2e` job, which spins up its own clean Firebase emulators