### PR TITLE
Default meta.decided: false on new applications

### DIFF
--- a/__tests__/applyFormHelpers.test.ts
+++ b/__tests__/applyFormHelpers.test.ts
@@ -12,6 +12,7 @@ describe('ApplyForm Helpers', () => {
       const app = createEmptyApplication()
       expect(app.personal.email).toBe('')
       expect(app.meta.submitted).toBe(false)
+      expect(app.meta.decided).toBe(false)
     })
 
     test('normalizeApplicationData fills user identity information when provided', () => {
@@ -24,6 +25,21 @@ describe('ApplyForm Helpers', () => {
       expect(app.meta.uid).toBe('uid123')
       // The uid is the only identifier stamped on an application.
       expect(app.meta).not.toHaveProperty('id')
+    })
+
+    test('normalizeApplicationData defaults meta.decided for a legacy doc missing the field', () => {
+      // A draft written before meta.decided existed has no such field at
+      // all - normalize should fill it in via the meta-specific deep merge,
+      // not silently drop it via the flat top-level spread.
+      const legacyDoc = {
+        personal: { email: 'legacy@example.com' },
+        meta: { uid: 'uid456', submitted: true },
+      }
+
+      const app = normalizeApplicationData(legacyDoc)
+      expect(app.meta.decided).toBe(false)
+      expect(app.meta.submitted).toBe(true)
+      expect(app.meta.uid).toBe('uid456')
     })
   })
 

--- a/src/data.d.ts
+++ b/src/data.d.ts
@@ -122,6 +122,7 @@ declare global {
         uid: string
         submitted: boolean
         interview: boolean
+        decided: boolean
       }
       timestamps: {
         created: Timestamp

--- a/src/lib/helpers/applyForm.ts
+++ b/src/lib/helpers/applyForm.ts
@@ -32,6 +32,7 @@ export function createEmptyApplication(): Data.Application {
       uid: '',
       submitted: false,
       interview: false,
+      decided: false,
     },
     timestamps: {
       created: null as any,
@@ -99,7 +100,20 @@ export function normalizeApplicationData(
   },
 ): Data.Application {
   const empty = createEmptyApplication()
-  const base = data ? { ...cloneDeep(empty), ...cloneDeep(data) } : empty
+  const base = data
+    ? {
+        ...cloneDeep(empty),
+        ...cloneDeep(data),
+        // Deep-merge meta specifically so a document written before a new
+        // meta field existed (e.g. legacy drafts predating meta.decided)
+        // still gets that field's default instead of the whole meta object
+        // being overwritten wholesale by the flat spread above.
+        meta: {
+          ...cloneDeep(empty.meta),
+          ...(data.meta ? cloneDeep(data.meta) : {}),
+        },
+      }
+    : empty
 
   if (userObj?.uid) base.meta.uid = userObj.uid
   if (userObj?.email) base.personal.email = userObj.email


### PR DESCRIPTION
## Summary

Companion to [gbstem/admin#41](https://github.com/gbstem/admin/pull/41), which replaces the applications `meta.decision` `DocumentReference` field with a plain `meta.decided` boolean (`meta.decision` was an injection vector: firestore.rules lets an applicant write their whole document, so an attacker could set it to an arbitrary path string, and admin server code that trusted it as a reference would fetch whatever document that string pointed to via the rule-bypassing Admin SDK — see the linked PR for the full writeup).

While tracing which app actually creates applications for that PR, found this repo never wrote `meta.decision` (or any placeholder) at all — portal's `Data.Application` type didn't even include the field. Firestore's `where(field, '==', null)`-style equality queries only match documents that *explicitly* have the field set to that value, not documents where the field is simply absent, so admin's "undecided" filter and dashboard "decided" count were likely already silently excluding every freshly-submitted application until some admin-side action touched it. `meta.decided: false`, set at creation, sidesteps that null-vs-missing ambiguity entirely.

## Changes
- `src/data.d.ts`: add `decided: boolean` to `Data.Application.meta`
- `src/lib/helpers/applyForm.ts`: default `meta.decided: false` in `createEmptyApplication()`; deep-merge `meta` specifically in `normalizeApplicationData` (matching the pattern `registrationForm.ts` already uses) so a returning applicant's pre-existing draft — which predates this field — gets it defaulted in rather than the flat top-level spread silently dropping it

## Test plan
- [x] `createEmptyApplication().meta.decided === false`
- [x] New test: `normalizeApplicationData` on a legacy doc missing `meta.decided` entirely correctly defaults it to `false` via the deep merge, rather than leaving it `undefined`
- [x] `yarn svelte-kit sync && yarn lint && yarn format:check && yarn run check && yarn test` — clean, 364/364 tests pass