### PR TITLE
Replace time-based Cypress waits with condition-based waits

### DIFF
--- a/cypress/e2e/classes.cy.ts
+++ b/cypress/e2e/classes.cy.ts
@@ -18,20 +18,17 @@ describe('Section D: Class Roster and Details View', () => {
 
     // 1. Select course filter
     cy.selectOption('input[placeholder="Filter by course"]', 'Python 1')
-    cy.wait(500)
     cy.get('body').should('contain', 'Python 1')
     // We should not see other courses if we filter by Python 1
     cy.contains('body', 'Scratch 1').should('not.exist')
 
     // Remove filter
     cy.selectOption('input[placeholder="Filter by course"]', 'all')
-    cy.wait(500)
     cy.get('body').should('contain', 'Python 1')
     cy.get('body').should('contain', 'Mathematics 2a')
 
     // 2. Toggle showing only enrolled classes
     cy.contains('button', 'Show all enrolled classes').click()
-    cy.wait(500)
     cy.contains('button', 'Show all classes').should('be.visible')
     // Python 1 (enrolled class) should still be visible
     cy.get('body').should('contain', 'Python 1')
@@ -40,7 +37,6 @@ describe('Section D: Class Roster and Details View', () => {
 
     // Toggle back to show all classes
     cy.contains('button', 'Show all classes').click()
-    cy.wait(500)
     cy.contains('button', 'Show all enrolled classes').should('be.visible')
     // Both Python 1 and Mathematics 2a should reappear
     cy.get('body').should('contain', 'Python 1')
@@ -53,6 +49,10 @@ describe('Section D: Class Roster and Details View', () => {
 
     // Wait for class details and student enrollment data to load
     cy.get('body').should('contain', 'Mathematics 2a')
+    // Empirically needed: removing this caused the enroll flow below to
+    // silently produce no success toast in a real test run, even though the
+    // card's text (and presumably its buttons) were already present -- some
+    // settle time beyond "the card text exists" is required here.
     cy.wait(500)
 
     // Enroll in a class and verify enrollment confirmation email (/api/enroll)
@@ -86,13 +86,11 @@ describe('Section D: Class Roster and Details View', () => {
 
     // 1. Select course filter
     cy.selectOption('input[placeholder="Filter by course"]', 'Python 1')
-    cy.wait(500)
     cy.get('body').should('contain', 'Python 1')
     cy.contains('body', 'Scratch 1').should('not.exist')
 
     // Remove filter
     cy.selectOption('input[placeholder="Filter by course"]', 'all')
-    cy.wait(500)
     cy.get('body').should('contain', 'Python 1')
     cy.get('body').should('contain', 'Scratch 1')
   })
@@ -104,6 +102,8 @@ describe('Section D: Class Roster and Details View', () => {
     // Verify instructor class schedule is visible and wait for student list to populate
     cy.contains('Next Upcoming Class:').should('be.visible')
     cy.get('body').should('contain', 'Python 1')
+    // Empirically needed: same as the enroll flow above -- removing this
+    // caused the reminder flow below to silently produce no success toast.
     cy.wait(1000)
 
     // Send class reminder to students and verify email (/api/remindStudents)

--- a/cypress/e2e/instructor.cy.ts
+++ b/cypress/e2e/instructor.cy.ts
@@ -27,10 +27,16 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
     })
 
     cy.visit('/apply')
-    cy.wait(2000) // Allow auto-save to start and complete
     cy.get('h1').should('contain', 'Apply')
 
-    // Wait for the form loading/saving to finish
+    // ApplyForm.svelte's onMount kicks off an async handleSave() that later
+    // reassigns the whole `values` object (ApplyForm.svelte:225), which resets
+    // bound form inputs -- the disabled check below only reflects the *saving*
+    // flag, which is still false both before that save starts and after it
+    // finishes, so it doesn't rule out typing landing mid-save. Verified via a
+    // real test run: without this wait, keystrokes into phoneNumber got
+    // scrambled (typed "5559876543" ended up as "55398").
+    cy.wait(2000)
     cy.get('input[name="personal.phoneNumber"]').should('not.be.disabled')
 
     // Fill application form details
@@ -76,7 +82,6 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
 
     // Reload the page
     cy.visit('/apply')
-    cy.wait(1500)
 
     // Verify submitted status is displayed
     cy.get('body').should('contain', 'Application submitted and in review!')
@@ -112,7 +117,6 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
     cy.get('a').contains('Community Service Hours Tracker').should('be.visible')
 
     cy.visit('/apply')
-    cy.wait(1500)
     cy.get('body').should('contain', 'Application submitted and in review!')
     cy.get('input[name="personal.phoneNumber"]').should('be.disabled')
   })
@@ -128,7 +132,6 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
     cy.get('a').contains('Community Service Hours Tracker').should('not.exist')
 
     cy.visit('/apply')
-    cy.wait(1500)
     cy.get('body').should('contain', 'Application submitted and in review!')
     cy.signOutViaUi()
   })
@@ -157,7 +160,6 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
 
     // Scenario 2: Book slot
     cy.visit('/dashboard')
-    cy.wait(1500)
     cy.get('input[type="radio"]')
       .first()
       .parent()
@@ -242,9 +244,9 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
       })
     cy.waitForNotification('Class details saved!')
 
-    // Wait for the 2-second timeout reload to trigger and load the page
-    cy.wait(2500)
-    cy.contains('h2', 'Class Details')
+    // The page does a location.reload() ~2000ms after this save -- give the
+    // lookup extra retry budget to span that instead of a fixed pre-wait.
+    cy.contains('h2', 'Class Details', { timeout: 8000 })
       .closest('.rounded-xl')
       .within(() => {
         cy.get('input[name="classCap"]')
@@ -311,8 +313,18 @@ describe('Section C & E: Instructor Applications & Community Service', () => {
     cy.waitForNotification('Sub request sent!')
     cy.get('[role="dialog"]').should('not.exist')
 
-    // Wait for window.location.reload() (which fires 1000ms after sub request) to finish
-    cy.wait(1500)
+    // window.location.reload() fires ~1000ms after the sub request -- give the
+    // lookup extra retry budget to span that instead of a fixed pre-wait.
+    cy.contains('h2', 'Sign Up To Substitute A Class', {
+      timeout: 8000,
+    }).should('be.visible')
+    // A full page reload resets the whole document, so unlike the lookup
+    // above (which only needs the content to exist and retries fine), the
+    // checkbox/submit click below needs the reloaded page to actually be
+    // interactive again -- verified via a real test run: without this,
+    // clicking immediately after the h2 appears occasionally lands before
+    // hydration finishes and the signup never fires.
+    cy.wait(500)
 
     // Sign up to substitute a class session and verify confirmation email (/api/substitute)
     cy.contains('h2', 'Sign Up To Substitute A Class')

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -32,7 +32,6 @@ describe('Section F: Profile Customization & Account Management', () => {
 
     // Visit profile
     cy.visit('/profile')
-    cy.wait(2000)
 
     // 2. Update Full Name
     cy.get('input[name="firstName"]').should('have.value', 'Profile')
@@ -49,7 +48,6 @@ describe('Section F: Profile Customization & Account Management', () => {
 
     // Verify persistence after reload
     cy.visit('/profile')
-    cy.wait(1000)
     cy.get('input[name="firstName"]').should('have.value', 'UpdatedFirst')
     cy.get('input[name="lastName"]').should('have.value', 'UpdatedLast')
 
@@ -78,8 +76,10 @@ describe('Section F: Profile Customization & Account Management', () => {
 
     // Reload and verify email field shows the updated email
     cy.visit('/profile')
-    cy.wait(2000)
-    cy.get('input[id="current-email"]').should('have.value', updatedEmail)
+    cy.get('input[id="current-email"]', { timeout: 8000 }).should(
+      'have.value',
+      updatedEmail,
+    )
 
     // 4. Change Password
     cy.fillInput('input[name="newPassword"]', newPassword)
@@ -138,6 +138,11 @@ describe('Section F: Profile Customization & Account Management', () => {
 
     // Visiting /apply as an instructor auto-creates a draft application doc.
     cy.visit('/apply')
+    // Empirically needed: without this, /apply rendered the student-facing
+    // "Student Account Creation" form instead of the instructor "Apply" form
+    // (verified via a real test run screenshot), meaning the instructor role
+    // claim set at signup hadn't yet propagated to this session -- so no
+    // draft application doc got created, and the exists-check below failed.
     cy.wait(2000)
 
     // getFirestoreUserId/checkFirestoreDocExists use the Admin SDK (cypress.config.ts task),

--- a/cypress/e2e/registration.cy.ts
+++ b/cypress/e2e/registration.cy.ts
@@ -33,7 +33,6 @@ describe('Section B: Student Registration & Account Management', () => {
   it('Test Case 6: Parent Registration - Manage Multiple Children', () => {
     cy.visit('/apply')
     cy.get('h1').should('contain', 'Student Account Creation')
-    cy.wait(1000) // Wait for Svelte page to settle
 
     // Assert Child 1 exists by default
     cy.get('input[name="select-a-child"]', { timeout: 10000 }).should(
@@ -44,7 +43,6 @@ describe('Section B: Student Registration & Account Management', () => {
     // Click "Add Child Account" to add new children up to maxChildrenPerAccount
     for (let i = 2; i <= maxChildrenPerAccount; i++) {
       cy.contains('button', 'Add Child Account').click()
-      cy.wait(300)
       cy.get('input[name="select-a-child"]').should('have.value', `Child ${i}`)
     }
 
@@ -59,7 +57,6 @@ describe('Section B: Student Registration & Account Management', () => {
   it('Test Case 7: Complete and Submit a Registration Form', () => {
     cy.visit('/apply')
     cy.get('h1').should('contain', 'Student Account Creation')
-    cy.wait(1000)
 
     // Select Child 1 to register
     cy.get('input[name="select-a-child"]', { timeout: 10000 }).should(
@@ -146,7 +143,6 @@ describe('Section B: Student Registration & Account Management', () => {
       `${studentFirst} ${studentLast}`,
       { timeout: 10000 },
     )
-    cy.wait(500)
 
     // Verify submitted values persist (should display the submitted account card layout)
     cy.get('body').should(

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -99,8 +99,11 @@ Cypress.Commands.add('signOutViaUi', () => {
 Cypress.Commands.add(
   'selectOption',
   (selector: string, text: string, options?: Partial<Cypress.Timeoutable>) => {
+    // Select.svelte populates filteredOptions synchronously from options
+    // already in memory on focus/open (no debounce applies until the user
+    // types), so the option button is already renderable -- no need to wait
+    // before the retrying .contains() below finds and clicks it.
     cy.get(selector, options).click({ force: true })
-    cy.wait(300)
     cy.contains('button', text, options).click({ force: true })
   },
 )

--- a/docs/known-issues/apply-form-autosave-race.md
+++ b/docs/known-issues/apply-form-autosave-race.md
@@ -1,0 +1,94 @@
+# ApplyForm autosave race can scramble in-progress typing
+
+**Status:** Not fixed. Documented here after being caught indirectly by a Cypress test; the test now waits around it instead of the form being made race-proof.
+
+## Summary
+
+`ApplyForm.svelte` (`src/lib/components/forms/ApplyForm.svelte`) kicks off an
+async save on mount, and that save eventually reassigns the whole `values`
+object the form's inputs are bound to. If a user starts typing before that
+save finishes, their keystrokes can land on an input that gets swapped out
+from under them mid-type, silently dropping or corrupting characters.
+
+This isn't hypothetical: a Cypress test (`cypress/e2e/instructor.cy.ts`, Test
+Case 8) reproduced it directly. Typing `5559876543` into the phone number
+field landed as `55398` when the test didn't pad extra time after page load
+before typing.
+
+## Root cause
+
+`onMount` (`ApplyForm.svelte:132-177`) subscribes to the user store and, for
+a new or normalized application, calls `handleSave()` without awaiting it
+(`ApplyForm.svelte:148-157`):
+
+```js
+values = normalizeApplicationData(values, user.object, user.profile)
+handleSave()
+// ...
+values = normalizeApplicationData(null, user.object, user.profile)
+handleSave()
+```
+
+`handleSave()` (`ApplyForm.svelte:184-235`) sets `saving = true`, awaits a
+Firestore write and then a re-fetch, and only then does this
+(`ApplyForm.svelte:224-228`):
+
+```js
+if (applicationData) {
+  values = cloneDeep(applicationData)
+  dbValues = cloneDeep(applicationData)
+}
+saving = false
+```
+
+`values = cloneDeep(applicationData)` replaces the entire bound object right
+before `saving` flips back to `false`. Every field bound into that object
+(via `FormInput`/`FormSelect`/etc.) is a candidate for losing its DOM node
+identity at that moment.
+
+The form's only guard against interacting too early is the `saving` flag
+(`ApplyForm.svelte:318`):
+
+```js
+disabled={values.meta.submitted || $submitting || saving}
+```
+
+`saving` is `false` in two very different situations that look identical
+from the outside: **before** the `onMount`-triggered save has started, and
+**after** it has fully finished. There's a window between page load and the
+first `saving = true` (while `onMount`'s own `await`s are still in flight)
+where the fieldset already reads "not disabled" even though the save/reassign
+cycle hasn't happened yet. A user (or a test) that starts typing as soon as
+inputs look enabled can end up typing during exactly that cycle.
+
+## Where this is currently worked around, not fixed
+
+`cypress/e2e/instructor.cy.ts` (Test Case 8, "Instructor Application
+Submission") pads a fixed 2-second wait after visiting `/apply` and before
+checking that the phone number input is enabled, with a comment pointing back
+to this file. That wait was restored deliberately after being removed and
+causing the scrambled-input failure described above — it isn't just leftover
+caution, it's currently the only thing standing between this bug and a flaky
+(or corrupted) real test run.
+
+## Suggested fix direction (not implemented)
+
+A few options, roughly in order of how surgical they are:
+
+1. **Expose a real "settled" signal.** Add a `hasLoaded`/`hasSavedOnce`
+   `$state` flag that only flips `true` after the `onMount` chain's _first_
+   `handleSave()` call (or the "no save needed" branch) has fully resolved,
+   and gate the fieldset's `disabled` on that too. This directly closes the
+   "before vs. after" ambiguity in the `saving` flag.
+2. **Avoid replacing the whole object.** Instead of
+   `values = cloneDeep(applicationData)` wholesale, merge only the fields
+   that differ from what's already in `values`/`$form`, so unrelated inputs
+   the user hasn't touched don't get new object identities.
+3. **Await the initial save before rendering inputs interactively**, e.g.
+   show a loading state until the `onMount` promise chain settles, rather
+   than relying on a derived `disabled` prop that can't distinguish
+   "not yet started" from "already done."
+
+Any of these would let the Cypress wait in `instructor.cy.ts` be replaced
+with a real condition (e.g. waiting on the new settled flag) instead of a
+fixed delay.


### PR DESCRIPTION
## Summary
- Removed or replaced 20 of 34 fixed-duration `cy.wait()` calls in the portal Cypress suite. The shared `selectOption` command's blind 300ms wait is gone entirely — `Select.svelte` renders its dropdown options synchronously on open, with no debounce until the user actually types — which alone covers ~15 call sites across every spec file. Several other waits were simply redundant given Cypress's own retrying assertions.
- The remaining 14 waits guard either the same signin/session-hydration timing intentionally left alone in the companion admin PR ([gbstem/admin#45](https://github.com/gbstem/admin/pull/45)), or constraints confirmed via repeated real test runs, not assumptions.
- Two of those verified constraints turned out to be real, if narrow, app issues rather than pure test flakiness:
  - **`ApplyForm.svelte` autosave race**: its `onMount` kicks off an async `handleSave()` that later reassigns the whole bound `values` object. The fieldset's `disabled` check only reflects the `saving` flag, which reads `false` both before that save starts and after it finishes, so it doesn't rule out typing landing mid-reassignment. Verified directly: with the wait removed, typing `"5559876543"` into the phone number field came out as `"55398"`. Documented in `docs/known-issues/apply-form-autosave-race.md` with a suggested fix direction — not fixed in this PR, since doing it properly is more involved than a wait swap.
  - **Reload → interact**: a full `location.reload()` after "Request Sub" resets the whole document, so content existing again doesn't mean it's interactive yet (same lesson as a similar admin bug). Addressed with a short settle wait scoped specifically to the post-reload interaction, rather than a blind pre-wait.

## Test plan
- [x] `yarn lint` clean
- [x] `yarn test` — 363/363 passing
- [x] Full Cypress suite run repeatedly against the shared emulator (multiple stress-test passes on the files that surfaced issues) — 30/30 passing, consistently reproduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xvs3bv4oo4682TiqdhR7Yf